### PR TITLE
merge master to python2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 # httpapiclient
+PyJWT >= 1.6.4
 pika >= 0.11.2
 certifi

--- a/src/smp/client.py
+++ b/src/smp/client.py
@@ -28,13 +28,12 @@ class SmpApiRequest(ApiRequest):
 
 
 class SmpApiClient(JsonResponseMixin, HelperMethodsMixin, BaseApiClient):
-    default_base_url = 'https://api.smp.io/'
     request_class = SmpApiRequest
 
     def __init__(self, base_url=None, basic_auth=None):
         super(SmpApiClient, self).__init__()
         if base_url is None:
-            base_url = self.default_base_url
+            base_url = 'https://api.smp.io/'
 
         self.base_url = base_url
         self.session.auth = basic_auth

--- a/src/smp/exceptions.py
+++ b/src/smp/exceptions.py
@@ -3,3 +3,7 @@ from __future__ import print_function, division, absolute_import, unicode_litera
 
 class NoMatchingCredential(Exception):
     """Credential for this operation not found."""
+
+
+class MultipleObjectsReturned(Exception):
+    pass

--- a/src/smp/mq.py
+++ b/src/smp/mq.py
@@ -25,7 +25,6 @@ def protect_from_disconnect(func):
 
 
 class SmpMqClient(object):
-    default_url = 'amqp+ssl://mq.smp.io:5671/'
     main_exchange = 'smp'
     requeue_message_on_exception = True
     unsubscribe_on_unknown_event = False
@@ -36,7 +35,7 @@ class SmpMqClient(object):
 
     def __init__(self, url=None, auth=None):
         if url is None:
-            url = self.default_url
+            url = 'amqp+ssl://mq.smp.io:5671/'
 
         self.cp = self.build_connection_params(url, auth)
         if self.cp.credentials:


### PR DESCRIPTION
в easypost в settings используются default_*url, оставил их атрибутами класса
SMP_BASE_URL = os.environ.get('SMP_BASE_URL', smp.SmpApiClient.default_base_url)
SMP_MQ_URL = os.environ.get('SMP_MQ_URL', smp.SmpMqClient.default_url)