### PR TITLE
mq: replace obsolete BlockingChannel method publish to basic_publish

### DIFF
--- a/src/smp/mq.py
+++ b/src/smp/mq.py
@@ -134,7 +134,7 @@ class SmpMqClient:
             delivery_mode=PERSISTENT_DELIVERY_MODE,
             headers=headers)
 
-        self.channel.publish(exchange=self.main_exchange, routing_key=routing_key, body=body, properties=properties)
+        self.channel.basic_publish(exchange=self.main_exchange, routing_key=routing_key, body=body, properties=properties)
         log.info('Published %s', routing_key)
 
     @protect_from_disconnect


### PR DESCRIPTION
Убрали метод BlockingChannel.publish
https://github.com/pika/pika/blob/0.13.0/pika/adapters/blocking_connection.py
https://github.com/pika/pika/blob/stable/pika/adapters/blocking_connection.py