### PR TITLE
client: force X-SMP-UserId to be a string #PLN-2299

### DIFF
--- a/src/smp/client.py
+++ b/src/smp/client.py
@@ -39,7 +39,7 @@ class SmpApiClient(JsonResponseMixin, HelperMethodsMixin, BaseApiClient):
         if basic_auth is not None:
             self.session.auth = basic_auth
             if user_id is not None:
-                self.session.headers['X-SMP-UserId'] = user_id
+                self.session.headers['X-SMP-UserId'] = str(user_id)
 
     def get_media_client(self, credential):
         return MediaClient(credential, session=self.session, base_url=self.base_url)


### PR DESCRIPTION
since 2.11.0:
> https://pypi.org/project/requests/2.11.0/
> Some previous releases accidentally accepted integers as acceptable header values. This release does not.
```
analytics.site_analytics_client ERROR Send error
Traceback (most recent call last):
  File "/Users/zok/git/easypost/analytics/site_analytics_client.py", line 29, in wrapped
    return fn(*args, **kwargs)
  File "/Users/zok/git/easypost/analytics/site_analytics_client.py", line 111, in track_event
    'async': _async
  File "/Users/zok/git/easypost/analytics/site_analytics_client.py", line 60, in _send
    json=data,
  File "/Users/zok/git/easypost/httpapiclient/base.py", line 46, in request
    prepared = self.session.prepare_request(request)
  File "/Users/zok/git/easypost/venv/lib/python2.7/site-packages/requests/sessions.py", line 437, in prepare_request
    hooks=merge_hooks(request.hooks, self.hooks),
  File "/Users/zok/git/easypost/venv/lib/python2.7/site-packages/requests/models.py", line 306, in prepare
    self.prepare_headers(headers)
  File "/Users/zok/git/easypost/venv/lib/python2.7/site-packages/requests/models.py", line 440, in prepare_headers
    check_header_validity(header)
  File "/Users/zok/git/easypost/venv/lib/python2.7/site-packages/requests/utils.py", line 872, in check_header_validity
    "bytes, not %s" % (name, value, type(value)))
InvalidHeader: Value for header {X-SMP-UserId: 2} must be of type str or bytes, not <type 'int'>
```