### PR TITLE
#PLN-2542 drop PyJWT restriction

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 # httpapiclient
-PyJWT >= 1.6.4, < 2.0
+PyJWT >= 1.6.4
 pika >= 1.0.1
 certifi


### PR DESCRIPTION
**DEPLOY UNSAFE**: *Easypost* and all services must be updated to use new `jwt.encode()`/`jwt.decode()` methods.